### PR TITLE
4 week

### DIFF
--- a/records/4Week_LeeEuiChan.md
+++ b/records/4Week_LeeEuiChan.md
@@ -1,0 +1,67 @@
+
+# 4Week 이의찬
+
+## 미션 요구사항 분석 & 체크리스트
+
+- [x] 네이버클라우드플랫폼을 통한 배포, 도메인 HTTPS까지 적용
+- [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 성별 필터링기능 구현
+- [x] 선택미션 - 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 호감사유 필터링기능 구현
+- [x] 선택미션 - 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 정렬기능
+- [ ] 선택미션 - 젠킨스를 통해서 리포지터리의 main 브랜치에 커밋 이벤트가 발생하면 자동으로 배포가 진행되도록
+
+## 4주차 미션 요약
+
+[접근방법]
+1. 네이버클라우드플랫폼을 통한 배포
+   - 강의대로 진행
+
+1. 필터링
+    - SearchFilter을 선언하고 @ModelAttribute을 통해 받음
+    ```java
+    @Setter
+    private static class SearchFilter {
+        private String gender;
+        private Integer attractiveTypeCode;
+        private Integer sortCode = 1; // 기본값
+    }
+    ```
+2. 호감리스트 성별 필터링기능 구현 
+   - QueryDsl을 이용하여 해결
+   - `BooleanExpression`을 활용하여 조건 분리
+    ```java
+    private BooleanExpression eqToInstaMember(InstaMember toInstaMember) {
+        return likeablePerson.toInstaMember.eq(toInstaMember);
+    }
+    
+    private BooleanExpression eqGender(String gender) {
+        if (gender == null || gender.equals("")) {
+            return null;
+        }
+        return likeablePerson.fromInstaMember.gender.eq(gender);
+    }
+    ```
+3. 호감사유 
+   - queryDsl을 활용하여 해결
+   - 2번과 같은 방식으로 해결
+   ```java
+    private BooleanExpression eqAttractiveTypeCode(Integer attractiveTypeCode) {
+        if (attractiveTypeCode == null) {
+            return null;
+        }
+        return likeablePerson.attractiveTypeCode.eq(attractiveTypeCode);
+    }
+    ```
+4. 정렬 기능
+    - queryDsl을 활용하여 해결
+    - orderBy에 OrderSpecifier 배열로 넘길 수 있기 때문에 `sortCode`의 리졸버를 만들어 정렬조건을 배열로 반환하였다.
+    ```java
+    public Q orderBy(OrderSpecifier<?>... o) {
+        return queryMixin.orderBy(o);
+    }
+    ```
+
+[특이사항]
+- 3주차 배포 21강까지 완료하였지만 Springboot앱이 실행이 안되는 오류 해결
+    - 문제점: application.yml에 ssl관련된 설정을 빼지 않았기 때문에 발생
+
+- SearchFilter를 통해 쿼리 스트링을 받는데 이 경우 조건이 추가되면 매번 Request DTO와 Service, QueryDsl을 모두 수정해야 한다. 이럴 때는 Map으로 받으로 받아서 자동으로 처리하는 게 맞을까?

--- a/records/4Week_LeeEuiChan.md
+++ b/records/4Week_LeeEuiChan.md
@@ -1,4 +1,3 @@
-
 # 4Week 이의찬
 
 ## 미션 요구사항 분석 & 체크리스트
@@ -15,17 +14,53 @@
 1. 네이버클라우드플랫폼을 통한 배포
    - 강의대로 진행
 
-1. 필터링
-    - SearchFilter을 선언하고 @ModelAttribute을 통해 받음
+2. Query String
+   - SearchFilter을 선언하고 `@ModelAttribute`을 통해 받음
     ```java
+    @PreAuthorize("isAuthenticated()")
+    @GetMapping("/toList")
+    public String showToList(Model model, SearchFilter searchFilter) {
+        InstaMember instaMember = rq.getMember().getInstaMember();
+
+        // 인스타인증을 했는지 체크
+        if (instaMember != null) {
+            // 해당 인스타회원이 좋아하는 사람들 목록
+            RsData likeablePeople = likeablePersonService.findByToInstaMemberWithFilter(
+                    instaMember, searchFilter.gender, searchFilter.attractiveTypeCode, searchFilter.sortCode
+            );
+            model.addAttribute("likeablePeople", likeablePeople.getData());
+        }
+
+        return "usr/likeablePerson/toList";
+    }
+
     @Setter
-    private static class SearchFilter {
+    public static class SearchFilter {
         private String gender;
         private Integer attractiveTypeCode;
-        private Integer sortCode = 1; // 기본값
+        private int sortCode = 1; // 기본값
     }
     ```
-2. 호감리스트 성별 필터링기능 구현 
+
+3. Query Dsl 코드
+
+    ```java
+    @Override
+    public List<LikeablePerson> findQslByToInstaMemberWithFilter(
+            InstaMember toInstaMember, String gender, Integer attractiveTypeCode, int sortCode) {
+        return jpaQueryFactory
+                .selectFrom(likeablePerson)
+                .where(
+                        eqToInstaMember(toInstaMember),
+                        eqGender(gender),
+                        eqAttractiveTypeCode(attractiveTypeCode)
+                )
+                .orderBy(resolveSortCode(sortCode))
+                .fetch();
+    }
+    ```
+
+4. 호감리스트 성별 필터링기능 구현
    - QueryDsl을 이용하여 해결
    - `BooleanExpression`을 활용하여 조건 분리
     ```java
@@ -40,7 +75,7 @@
         return likeablePerson.fromInstaMember.gender.eq(gender);
     }
     ```
-3. 호감사유 
+5. 호감사유
    - queryDsl을 활용하여 해결
    - 2번과 같은 방식으로 해결
    ```java
@@ -51,17 +86,38 @@
         return likeablePerson.attractiveTypeCode.eq(attractiveTypeCode);
     }
     ```
-4. 정렬 기능
-    - queryDsl을 활용하여 해결
-    - orderBy에 OrderSpecifier 배열로 넘길 수 있기 때문에 `sortCode`의 리졸버를 만들어 정렬조건을 배열로 반환하였다.
+6. 정렬 기능
+   - queryDsl을 활용하여 해결
+   - orderBy에 OrderSpecifier 배열로 넘길 수 있기 때문에 `sortCode`의 리졸버를 만들어 정렬조건을 배열로 반환하였다.
     ```java
     public Q orderBy(OrderSpecifier<?>... o) {
         return queryMixin.orderBy(o);
     }
     ```
+   - 코드
+    ```java
+    private OrderSpecifier[] resolveSortCode(Integer sortCode) {
+        List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
+        switch (sortCode) {
+            case 2 -> orderSpecifiers.add(likeablePerson.modifyDate.asc());
+            case 3 -> orderSpecifiers.add(likeablePerson.fromInstaMember.toLikeablePeople.size().desc());
+            case 4 -> orderSpecifiers.add(likeablePerson.fromInstaMember.toLikeablePeople.size().asc());
+            case 5 -> {
+                orderSpecifiers.add(likeablePerson.fromInstaMember.gender.desc());
+                orderSpecifiers.add(likeablePerson.modifyDate.desc());
+            }
+            case 6 -> {
+                orderSpecifiers.add(likeablePerson.attractiveTypeCode.asc());
+                orderSpecifiers.add(likeablePerson.modifyDate.desc());
+            }
+            default -> orderSpecifiers.add(likeablePerson.modifyDate.desc());
+        }
+        return orderSpecifiers.toArray(new OrderSpecifier[orderSpecifiers.size()]);
+    }
+    ```
 
 [특이사항]
 - 3주차 배포 21강까지 완료하였지만 Springboot앱이 실행이 안되는 오류 해결
-    - 문제점: application.yml에 ssl관련된 설정을 빼지 않았기 때문에 발생
+   - 문제점: application.yml에 ssl관련된 설정을 빼지 않았기 때문에 발생
 
 - SearchFilter를 통해 쿼리 스트링을 받는데 이 경우 조건이 추가되면 매번 Request DTO와 Service, QueryDsl을 모두 수정해야 한다. 이럴 때는 Map으로 받으로 받아서 자동으로 처리하는 게 맞을까?

--- a/src/main/java/com/ll/gramgram/base/appConfig/AppConfig.java
+++ b/src/main/java/com/ll/gramgram/base/appConfig/AppConfig.java
@@ -1,7 +1,11 @@
 package com.ll.gramgram.base.appConfig;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import java.time.LocalDateTime;
@@ -11,13 +15,13 @@ public class AppConfig {
     @Getter
     private static long likeablePersonFromMax;
 
+    @Getter
+    private static long likeablePersonModifyCoolTime;
+
     @Value("${custom.likeablePerson.from.max}")
     public void setLikeablePersonFromMax(long likeablePersonFromMax) {
         AppConfig.likeablePersonFromMax = likeablePersonFromMax;
     }
-
-    @Getter
-    private static long likeablePersonModifyCoolTime;
 
     @Value("${custom.likeablePerson.modifyCoolTime}")
     public void setLikeablePersonModifyCoolTime(long likeablePersonModifyCoolTime) {

--- a/src/main/java/com/ll/gramgram/base/initData/NotProd.java
+++ b/src/main/java/com/ll/gramgram/base/initData/NotProd.java
@@ -65,7 +65,14 @@ public class NotProd {
                 LikeablePerson likeablePersonToinstaUser100 = likeablePersonService.like(memberUser3, "insta_user100", 2).getData();
                 Ut.reflection.setFieldValue(likeablePersonToinstaUser100, "modifyUnlockDate", LocalDateTime.now().minusSeconds(1));
 
+                likeablePersonService.like(memberUser2, "insta_user3", 2);
+                likeablePersonService.like(memberUser4, "insta_user3", 2);
+                likeablePersonService.like(memberUser6ByKakao, "insta_user3", 2);
+
+                likeablePersonService.like(memberUser6ByKakao, "insta_user5", 2);
+
                 likeablePersonService.like(memberUser3, "insta_user6", 2);
+
                 LikeablePerson likeablePersonKakao = likeablePersonService.like(memberUser5, "insta_user6", 2).getData();
                 Ut.reflection.setFieldValue(likeablePersonKakao, "modifyUnlockDate", LocalDateTime.now().minusHours(4));
                 likeablePersonService.like(memberUser5, "insta_user6", 1);

--- a/src/main/java/com/ll/gramgram/base/initData/NotProd.java
+++ b/src/main/java/com/ll/gramgram/base/initData/NotProd.java
@@ -76,6 +76,7 @@ public class NotProd {
                 LikeablePerson likeablePersonKakao = likeablePersonService.like(memberUser5, "insta_user6", 2).getData();
                 Ut.reflection.setFieldValue(likeablePersonKakao, "modifyUnlockDate", LocalDateTime.now().minusHours(4));
                 likeablePersonService.like(memberUser5, "insta_user6", 1);
+                likeablePersonService.like(memberUser2, "insta_user6", 1);
 
             }
         };

--- a/src/main/java/com/ll/gramgram/boundedContext/instaMember/service/InstaMemberService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/instaMember/service/InstaMemberService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -142,6 +142,6 @@ public class LikeablePersonController {
     public static class SearchFilter {
         private String gender;
         private Integer attractiveTypeCode;
-        private Integer sortCode = 1; // 기본값
+        private int sortCode = 1; // 기본값
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -129,18 +129,19 @@ public class LikeablePersonController {
         // 인스타인증을 했는지 체크
         if (instaMember != null) {
             // 해당 인스타회원이 좋아하는 사람들 목록
-            List<LikeablePerson> likeablePeople = instaMember.getToLikeablePeople();
-            model.addAttribute("likeablePeople", likeablePeople);
+            RsData likeablePeople = likeablePersonService.findByToInstaMemberWithFilter(
+                    instaMember, searchFilter.gender, searchFilter.attractiveTypeCode, searchFilter.sortCode
+            );
+            model.addAttribute("likeablePeople", likeablePeople.getData());
         }
 
         return "usr/likeablePerson/toList";
     }
 
     @Setter
-    private static class SearchFilter {
+    public static class SearchFilter {
         private String gender;
         private Integer attractiveTypeCode;
         private Integer sortCode = 1; // 기본값
     }
-
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonController.java
@@ -10,6 +10,7 @@ import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -122,7 +123,7 @@ public class LikeablePersonController {
 
     @PreAuthorize("isAuthenticated()")
     @GetMapping("/toList")
-    public String showToList(Model model) {
+    public String showToList(Model model, SearchFilter searchFilter) {
         InstaMember instaMember = rq.getMember().getInstaMember();
 
         // 인스타인증을 했는지 체크
@@ -134,4 +135,12 @@ public class LikeablePersonController {
 
         return "usr/likeablePerson/toList";
     }
+
+    @Setter
+    private static class SearchFilter {
+        private String gender;
+        private Integer attractiveTypeCode;
+        private Integer sortCode = 1; // 기본값
+    }
+
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepository.java
@@ -1,12 +1,15 @@
 package com.ll.gramgram.boundedContext.likeablePerson.repository;
 
 import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface LikeablePersonRepository extends JpaRepository<LikeablePerson, Long>, LikeablePersonRepositoryCustom {
+
     List<LikeablePerson> findByFromInstaMemberId(Long fromInstaMemberId);
 
     List<LikeablePerson> findByToInstaMember_username(String username);

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryCustom.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryCustom.java
@@ -10,5 +10,5 @@ public interface LikeablePersonRepositoryCustom {
     Optional<LikeablePerson> findQslByFromInstaMemberIdAndToInstaMember_username(long fromInstaMemberId, String toInstaMemberUsername);
 
     List<LikeablePerson> findQslByToInstaMemberWithFilter(
-            InstaMember toInstaMember, String gender, Integer attractiveTypeCode, Integer sortCode);
+            InstaMember toInstaMember, String gender, Integer attractiveTypeCode, int sortCode);
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryCustom.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryCustom.java
@@ -1,9 +1,14 @@
 package com.ll.gramgram.boundedContext.likeablePerson.repository;
 
+import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface LikeablePersonRepositoryCustom {
     Optional<LikeablePerson> findQslByFromInstaMemberIdAndToInstaMember_username(long fromInstaMemberId, String toInstaMemberUsername);
+
+    List<LikeablePerson> findQslByToInstaMemberWithFilter(
+            InstaMember toInstaMember, String gender, Integer attractiveTypeCode, Integer sortCode);
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
@@ -2,16 +2,20 @@ package com.ll.gramgram.boundedContext.likeablePerson.repository;
 
 import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
 import static com.ll.gramgram.boundedContext.likeablePerson.entity.QLikeablePerson.likeablePerson;
 
 @RequiredArgsConstructor
+@Slf4j
 public class LikeablePersonRepositoryImpl implements LikeablePersonRepositoryCustom {
     private final JPAQueryFactory jpaQueryFactory;
 
@@ -32,14 +36,19 @@ public class LikeablePersonRepositoryImpl implements LikeablePersonRepositoryCus
 
     @Override
     public List<LikeablePerson> findQslByToInstaMemberWithFilter(
-            InstaMember toInstaMember ,String gender, Integer attractiveTypeCode, Integer sortCode) {
+            InstaMember toInstaMember, String gender, Integer attractiveTypeCode, Integer sortCode) {
         if (toInstaMember == null) {
             return null;
         }
 
         return jpaQueryFactory
                 .selectFrom(likeablePerson)
-                .where(eqToInstaMember(toInstaMember), eqGender(gender), eqAttractiveTypeCode(attractiveTypeCode))
+                .where(
+                        eqToInstaMember(toInstaMember),
+                        eqGender(gender),
+                        eqAttractiveTypeCode(attractiveTypeCode)
+                )
+                .orderBy(resolveSortCode(sortCode))
                 .fetch();
     }
 
@@ -59,5 +68,24 @@ public class LikeablePersonRepositoryImpl implements LikeablePersonRepositoryCus
             return null;
         }
         return likeablePerson.attractiveTypeCode.eq(attractiveTypeCode);
+    }
+
+    private OrderSpecifier[] resolveSortCode(Integer sortCode) {
+        List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
+        switch (sortCode) {
+            case 2 -> orderSpecifiers.add(likeablePerson.modifyDate.asc());
+            case 3 -> orderSpecifiers.add(likeablePerson.fromInstaMember.fromLikeablePeople.size().desc());
+            case 4 -> orderSpecifiers.add(likeablePerson.fromInstaMember.fromLikeablePeople.size().asc());
+            case 5 -> {
+                orderSpecifiers.add(likeablePerson.fromInstaMember.gender.desc());
+                orderSpecifiers.add(likeablePerson.modifyDate.desc());
+            }
+            case 6 -> {
+                orderSpecifiers.add(likeablePerson.attractiveTypeCode.asc());
+                orderSpecifiers.add(likeablePerson.modifyDate.desc());
+            }
+            default -> orderSpecifiers.add(likeablePerson.modifyDate.desc());
+        }
+        return orderSpecifiers.toArray(new OrderSpecifier[orderSpecifiers.size()]);
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
@@ -36,7 +36,7 @@ public class LikeablePersonRepositoryImpl implements LikeablePersonRepositoryCus
 
     @Override
     public List<LikeablePerson> findQslByToInstaMemberWithFilter(
-            InstaMember toInstaMember, String gender, Integer attractiveTypeCode, Integer sortCode) {
+            InstaMember toInstaMember, String gender, Integer attractiveTypeCode, int sortCode) {
         if (toInstaMember == null) {
             return null;
         }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
@@ -74,8 +74,8 @@ public class LikeablePersonRepositoryImpl implements LikeablePersonRepositoryCus
         List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
         switch (sortCode) {
             case 2 -> orderSpecifiers.add(likeablePerson.modifyDate.asc());
-            case 3 -> orderSpecifiers.add(likeablePerson.fromInstaMember.fromLikeablePeople.size().desc());
-            case 4 -> orderSpecifiers.add(likeablePerson.fromInstaMember.fromLikeablePeople.size().asc());
+            case 3 -> orderSpecifiers.add(likeablePerson.fromInstaMember.toLikeablePeople.size().desc());
+            case 4 -> orderSpecifiers.add(likeablePerson.fromInstaMember.toLikeablePeople.size().asc());
             case 5 -> {
                 orderSpecifiers.add(likeablePerson.fromInstaMember.gender.desc());
                 orderSpecifiers.add(likeablePerson.modifyDate.desc());

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/repository/LikeablePersonRepositoryImpl.java
@@ -1,9 +1,12 @@
 package com.ll.gramgram.boundedContext.likeablePerson.repository;
 
+import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
 import java.util.Optional;
 
 import static com.ll.gramgram.boundedContext.likeablePerson.entity.QLikeablePerson.likeablePerson;
@@ -25,5 +28,36 @@ public class LikeablePersonRepositoryImpl implements LikeablePersonRepositoryCus
                         )
                         .fetchOne()
         );
+    }
+
+    @Override
+    public List<LikeablePerson> findQslByToInstaMemberWithFilter(
+            InstaMember toInstaMember ,String gender, Integer attractiveTypeCode, Integer sortCode) {
+        if (toInstaMember == null) {
+            return null;
+        }
+
+        return jpaQueryFactory
+                .selectFrom(likeablePerson)
+                .where(eqToInstaMember(toInstaMember), eqGender(gender), eqAttractiveTypeCode(attractiveTypeCode))
+                .fetch();
+    }
+
+    private BooleanExpression eqToInstaMember(InstaMember toInstaMember) {
+        return likeablePerson.toInstaMember.eq(toInstaMember);
+    }
+
+    private BooleanExpression eqGender(String gender) {
+        if (gender == null || gender.equals("")) {
+            return null;
+        }
+        return likeablePerson.fromInstaMember.gender.eq(gender);
+    }
+
+    private BooleanExpression eqAttractiveTypeCode(Integer attractiveTypeCode) {
+        if (attractiveTypeCode == null) {
+            return null;
+        }
+        return likeablePerson.attractiveTypeCode.eq(attractiveTypeCode);
     }
 }

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -223,8 +223,8 @@ public class LikeablePersonService {
         return RsData.of("S-1", "호감사유변경이 가능합니다.");
     }
 
-    public RsData findByToInstaMemberWithFilter(
-            InstaMember toInstaMember, String gender, Integer attractiveTypeCode, Integer sortCode) {
+    public RsData<List<LikeablePerson>> findByToInstaMemberWithFilter(
+            InstaMember toInstaMember, String gender, Integer attractiveTypeCode, int sortCode) {
 
         List<LikeablePerson> likeablePeople = likeablePersonRepository
                 .findQslByToInstaMemberWithFilter(toInstaMember, gender, attractiveTypeCode, sortCode);

--- a/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
+++ b/src/main/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonService.java
@@ -9,6 +9,7 @@ import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import com.ll.gramgram.boundedContext.instaMember.service.InstaMemberService;
 import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
 import com.ll.gramgram.boundedContext.likeablePerson.repository.LikeablePersonRepository;
+import com.ll.gramgram.boundedContext.likeablePerson.repository.LikeablePersonRepositoryCustom;
 import com.ll.gramgram.boundedContext.member.entity.Member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -215,9 +216,18 @@ public class LikeablePersonService {
             return RsData.of("F-2", "해당 호감표시를 취소할 권한이 없습니다.");
         }
 
-        if (!likeablePerson.isModifyUnlocked()) return RsData.of("F-3", "아직 호감사유변경을 할 수 없습니다. %s에는 가능합니다."
+        if (!likeablePerson.isModifyUnlocked())
+            return RsData.of("F-3", "아직 호감사유변경을 할 수 없습니다. %s에는 가능합니다."
                 .formatted(likeablePerson.getModifyUnlockDateRemainStrHuman()));
 
         return RsData.of("S-1", "호감사유변경이 가능합니다.");
+    }
+
+    public RsData findByToInstaMemberWithFilter(
+            InstaMember toInstaMember, String gender, Integer attractiveTypeCode, Integer sortCode) {
+
+        List<LikeablePerson> likeablePeople = likeablePersonRepository
+                .findQslByToInstaMemberWithFilter(toInstaMember, gender, attractiveTypeCode, sortCode);
+        return RsData.of("S-1", "", likeablePeople);
     }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/controller/LikeablePersonControllerTests.java
@@ -391,4 +391,21 @@ public class LikeablePersonControllerTests {
 
         assertThat(newAttractiveTypeCode).isEqualTo(2);
     }
+
+    @Test
+    @DisplayName("내가 받은 호감 검색 조건 테스트 - 성별 필터링 기능")
+    @WithUserDetails("KAKAO__2733176945")
+    void t016() throws Exception {
+        ResultActions resultActions =
+                mvc.perform(get("/usr/likeablePerson/toList")
+                                .with(csrf())
+                        .queryParam("gender", "W")
+                        .queryParam("attractiveTypeCode", "1")
+                        .queryParam("sortCode", "1"))
+                        .andDo(print());
+        resultActions
+                .andExpect(handler().handlerType(LikeablePersonController.class))
+                .andExpect(handler().methodName("showToList"))
+                .andExpect(status().is2xxSuccessful());
+    }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
@@ -303,7 +303,7 @@ public class LikeablePersonServiceTests {
                 .fetch();
 
         System.out.println(likeablePeople);
-        assertThat(likeablePeople.size()).isEqualTo(2);
+        assertThat(likeablePeople.size()).isEqualTo(3);
     }
 
     @Test
@@ -339,7 +339,7 @@ public class LikeablePersonServiceTests {
 
         //then
         assertThat(likeablePeople.size()).isGreaterThan(0);
-        assertThat(likeablePeople2.size()).isEqualTo(0);
+        assertThat(likeablePeople2.size()).isEqualTo(1);
         assertThat(likeablePeople3.size()).isGreaterThan(0);
     }
 
@@ -381,6 +381,10 @@ public class LikeablePersonServiceTests {
         List<LikeablePerson> likeablePeople = likeablePersonService
                 .findByToInstaMemberWithFilter(toInstaMember, gender, null, 1)
                 .getData();
+
+        likeablePeople.forEach(
+                lp -> assertThat(lp.getFromInstaMember().getGender()).isEqualTo(gender)
+        );
 
         //then
         assertThat(likeablePeople.size()).isEqualTo(2);

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
@@ -407,5 +407,22 @@ public class LikeablePersonServiceTests {
 
     }
 
-    
+    @Test
+    @DisplayName("필터링 기능 테스트 - 정렬 - 인기도 많은 순")
+    void t015() {
+        //given
+        String instaUserName = "insta_user6";
+        InstaMember toInstaMember = instaMemberService.findByUsername(instaUserName)
+                .orElseThrow(() -> new RuntimeException("데이터가 없습니다. NotProd.java 참조"));
+
+        //when
+        List<LikeablePerson> likeablePeople = likeablePersonService
+                .findByToInstaMemberWithFilter(toInstaMember, null, null, 3)
+                .getData();
+
+        for (int i = 0; i < likeablePeople.size() - 1; i++) {
+            assertThat(likeablePeople.get(i).getFromInstaMember().getToLikeablePeople().size())
+                    .isGreaterThan(likeablePeople.get(i + 1).getFromInstaMember().getToLikeablePeople().size());
+        }
+    }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
@@ -3,6 +3,7 @@ package com.ll.gramgram.boundedContext.likeablePerson.service;
 
 import com.ll.gramgram.TestUt;
 import com.ll.gramgram.base.appConfig.AppConfig;
+import com.ll.gramgram.base.rsData.RsData;
 import com.ll.gramgram.boundedContext.instaMember.entity.InstaMember;
 import com.ll.gramgram.boundedContext.instaMember.service.InstaMemberService;
 import com.ll.gramgram.boundedContext.likeablePerson.entity.LikeablePerson;
@@ -364,5 +365,24 @@ public class LikeablePersonServiceTests {
 
         //then
         assertThat(likeablePeople.size()).isEqualTo(1);
+    }
+
+
+    @Test
+    @DisplayName("필터링 기능 테스트 - 성별")
+    void t013() {
+        //given
+        String gender = "W";
+        String instaUserName = "insta_user6";
+        InstaMember toInstaMember = instaMemberService.findByUsername(instaUserName)
+                .orElseThrow(() -> new RuntimeException("데이터가 없습니다. NotProd.java 참조"));
+
+        //when
+        List<LikeablePerson> likeablePeople = likeablePersonService
+                .findByToInstaMemberWithFilter(toInstaMember, "W", null, 1)
+                .getData();
+
+        //then
+        assertThat(likeablePeople.size()).isEqualTo(2);
     }
 }

--- a/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
+++ b/src/test/java/com/ll/gramgram/boundedContext/likeablePerson/service/LikeablePersonServiceTests.java
@@ -379,10 +379,33 @@ public class LikeablePersonServiceTests {
 
         //when
         List<LikeablePerson> likeablePeople = likeablePersonService
-                .findByToInstaMemberWithFilter(toInstaMember, "W", null, 1)
+                .findByToInstaMemberWithFilter(toInstaMember, gender, null, 1)
                 .getData();
 
         //then
         assertThat(likeablePeople.size()).isEqualTo(2);
     }
+
+    @Test
+    @DisplayName("필터링 기능 테스트 - 호감사유")
+    void t014() {
+        //given
+        Integer attractiveTypeCode = 1;
+        String instaUserName = "insta_user6";
+        InstaMember toInstaMember = instaMemberService.findByUsername(instaUserName)
+                .orElseThrow(() -> new RuntimeException("데이터가 없습니다. NotProd.java 참조"));
+
+        //when
+        List<LikeablePerson> likeablePeople = likeablePersonService
+                .findByToInstaMemberWithFilter(toInstaMember, null, attractiveTypeCode, 1)
+                .getData();
+
+        //then
+        likeablePeople.forEach(
+                        lp -> assertThat(lp.getAttractiveTypeCode()).isEqualTo(attractiveTypeCode)
+                );
+
+    }
+
+    
 }


### PR DESCRIPTION
# 4Week 이의찬

## 미션 요구사항 분석 & 체크리스트

- [x] 네이버클라우드플랫폼을 통한 배포, 도메인 HTTPS까지 적용
- [x] 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 성별 필터링기능 구현
- [x] 선택미션 - 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 호감사유 필터링기능 구현
- [x] 선택미션 - 내가 받은 호감리스트(/usr/likeablePerson/toList)에서 정렬기능
- [ ] 선택미션 - 젠킨스를 통해서 리포지터리의 main 브랜치에 커밋 이벤트가 발생하면 자동으로 배포가 진행되도록

## 4주차 미션 요약

[접근방법]
1. 네이버클라우드플랫폼을 통한 배포
   - 강의대로 진행

2. Query String
    - SearchFilter을 선언하고 `@ModelAttribute`을 통해 받음
    ```java
    @PreAuthorize("isAuthenticated()")
    @GetMapping("/toList")
    public String showToList(Model model, SearchFilter searchFilter) {
        InstaMember instaMember = rq.getMember().getInstaMember();

        // 인스타인증을 했는지 체크
        if (instaMember != null) {
            // 해당 인스타회원이 좋아하는 사람들 목록
            RsData likeablePeople = likeablePersonService.findByToInstaMemberWithFilter(
                    instaMember, searchFilter.gender, searchFilter.attractiveTypeCode, searchFilter.sortCode
            );
            model.addAttribute("likeablePeople", likeablePeople.getData());
        }

        return "usr/likeablePerson/toList";
    }

    @Setter
    public static class SearchFilter {
        private String gender;
        private Integer attractiveTypeCode;
        private int sortCode = 1; // 기본값
    }
    ```

3. Query Dsl 코드

    ```java
    @Override
    public List<LikeablePerson> findQslByToInstaMemberWithFilter(
            InstaMember toInstaMember, String gender, Integer attractiveTypeCode, int sortCode) {
        return jpaQueryFactory
                .selectFrom(likeablePerson)
                .where(
                        eqToInstaMember(toInstaMember),
                        eqGender(gender),
                        eqAttractiveTypeCode(attractiveTypeCode)
                )
                .orderBy(resolveSortCode(sortCode))
                .fetch();
    }
    ```

4. 호감리스트 성별 필터링기능 구현 
   - QueryDsl을 이용하여 해결
   - `BooleanExpression`을 활용하여 조건 분리
    ```java
    private BooleanExpression eqToInstaMember(InstaMember toInstaMember) {
        return likeablePerson.toInstaMember.eq(toInstaMember);
    }
    
    private BooleanExpression eqGender(String gender) {
        if (gender == null || gender.equals("")) {
            return null;
        }
        return likeablePerson.fromInstaMember.gender.eq(gender);
    }
    ```
5. 호감사유 
   - queryDsl을 활용하여 해결
   - 2번과 같은 방식으로 해결
   ```java
    private BooleanExpression eqAttractiveTypeCode(Integer attractiveTypeCode) {
        if (attractiveTypeCode == null) {
            return null;
        }
        return likeablePerson.attractiveTypeCode.eq(attractiveTypeCode);
    }
    ```
6. 정렬 기능
    - queryDsl을 활용하여 해결
    - orderBy에 OrderSpecifier 배열로 넘길 수 있기 때문에 `sortCode`의 리졸버를 만들어 정렬조건을 배열로 반환하였다.
    ```java
    public Q orderBy(OrderSpecifier<?>... o) {
        return queryMixin.orderBy(o);
    }
    ```
    - 코드
    ```java
    private OrderSpecifier[] resolveSortCode(int sortCode) {
        List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
        switch (sortCode) {
            case 2 -> orderSpecifiers.add(likeablePerson.modifyDate.asc());
            case 3 -> orderSpecifiers.add(likeablePerson.fromInstaMember.toLikeablePeople.size().desc());
            case 4 -> orderSpecifiers.add(likeablePerson.fromInstaMember.toLikeablePeople.size().asc());
            case 5 -> {
                orderSpecifiers.add(likeablePerson.fromInstaMember.gender.desc());
                orderSpecifiers.add(likeablePerson.modifyDate.desc());
            }
            case 6 -> {
                orderSpecifiers.add(likeablePerson.attractiveTypeCode.asc());
                orderSpecifiers.add(likeablePerson.modifyDate.desc());
            }
            default -> orderSpecifiers.add(likeablePerson.modifyDate.desc());
        }
        return orderSpecifiers.toArray(new OrderSpecifier[orderSpecifiers.size()]);
    }
    ```

[특이사항]
- 3주차 배포 21강까지 완료하였지만 Springboot앱이 실행이 안되는 오류 해결
    - 문제점: application.yml에 ssl관련된 설정을 빼지 않았기 때문에 발생
- SearchFilter를 통해 쿼리 스트링을 받는데 이 경우 조건이 추가되면 매번 Request DTO와 Service, QueryDsl을 모두 수정해야 한다. 이럴 때는 Map으로 받으로 받아서 자동으로 처리하는 게 맞을까?

[래팩토링]
이의찬
- [x] resolveSortCode() -> orderBySortCode()
- [x] modifyDate -> id
- [x] likeablePerson.fromInstaMember.toLikeablePeople.size() -> InstaMemberBase에 있는 데이터 사용
- [ ] 테스트 코드 추가
- [x] SearchFilter -> SearchFilterForm
